### PR TITLE
Extend package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "eslint . "
+    "lint": "eslint . && ls-lint && jscpd .",
+    "test": "npm run lint"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "scripts": {
+    "prepare": "husky install",
     "lint": "eslint . && ls-lint && jscpd .",
     "test": "npm run lint"
   },


### PR DESCRIPTION
- Add missing [`husky install`](https://typicode.github.io/husky/#/?id=install).
- Extend `lint` script to run `jscpd` and `ls-lint`.